### PR TITLE
Change disconnect function to avoid CLOSE_WAIT

### DIFF
--- a/Net/Socket.php
+++ b/Net/Socket.php
@@ -115,8 +115,7 @@ class Net_Socket extends PEAR
                      $timeout = null, $options = null)
     {
         if (is_resource($this->fp)) {
-            @fclose($this->fp);
-            $this->fp = null;
+            $this->disconnect(false);
         }
 
         if (!$addr) {
@@ -185,12 +184,28 @@ class Net_Socket extends PEAR
      * @access public
      * @return mixed true on success or a PEAR_Error instance otherwise
      */
-    function disconnect()
+    function disconnect($return_error=true)
     {
         if (!is_resource($this->fp)) {
-            return $this->raiseError('not connected');
+	    if($return_error) return $this->raiseError('not connected');
+            return true;
         }
-
+	if(function_exists('socket_shutdown')){
+	    // force some options and execute shutdown, to avoid CLOSE_WAIT status
+	    if(defined('IPPROTO_TCP') && defined('TCP_NO_DELAY'))
+	        @socket_set_option($this->fp, IPPROTO_TCP, TCP_NODELAY, 1);
+	    if(defined('SO_KEEPALIVE'))
+	        @socket_set_option($this->fp, SOL_SOCKET, SO_KEEPALIVE, 0);
+	    if(defined('SO_LINGER'))
+	        @socket_set_option($this->fp, SOL_SOCKET, SO_LINGER, array('l_onoff'=>0,'l_linger'=>0));
+	    if(defined('SO_RCVTIMEO'))
+	        @socket_set_option($this->fp, SOL_SOCKET, SO_RCVTIMEO, array("sec"=>0, "usec"=>100));
+	    if(defined('SO_SNDTIMEO'))
+	        @socket_set_option($this->fp, SOL_SOCKET, SO_SNDTIMEO, array("sec"=>0, "usec"=>100));
+	    @socket_set_block($this->fp);
+	    @socket_shutdown($this->fp,2);
+	    @socket_close($this->fp);
+	}
         @fclose($this->fp);
         $this->fp = null;
         return true;


### PR DESCRIPTION
using net_smtp with a endless script, this net_socket cause a CLOSE_WAIT, these changes to disconnect() avoid this problem, added a new parameter to disconnect($return_error=true) that will set to false when executing connect() and $this->fp is a resource

```
    if (is_resource($this->fp)) {
        $this->disconnect(false);
    }
```
