### PR TITLE
Fix for "Maximum execution time of 30 seconds exceeded" error

### DIFF
--- a/Net/Socket.php
+++ b/Net/Socket.php
@@ -601,7 +601,9 @@ class Net_Socket extends PEAR
         }
 
         $data = '';
-        while (!feof($this->fp)) {
+        $timeout = time() + $this->timeout;
+
+        while (!feof($this->fp) && (!$this->timeout || time() < $timeout)) {
             $data .= @fread($this->fp, $this->lineLength);
         }
         return $data;


### PR DESCRIPTION
Fixes [Bug #17484](https://pear.php.net/bugs/bug.php?id=17484).
