### PR TITLE
Change license to BSD-2-Clause [pear bug 17526]

### DIFF
--- a/Net/Socket.php
+++ b/Net/Socket.php
@@ -4,25 +4,42 @@
  *
  * PHP Version 5
  *
- * Copyright (c) 1997-2013 The PHP Group
+ * LICENSE:
  *
- * This source file is subject to version 2.0 of the PHP license,
- * that is bundled with this package in the file LICENSE, and is
- * available at through the world-wide-web at
- * http://www.php.net/license/2_02.txt.
- * If you did not receive a copy of the PHP license and are unable to
- * obtain it through the world-wide-web, please send a note to
- * license@php.net so we can mail you a copy immediately.
+ * Copyright (c) 1997-2003 The PHP Group
+ * All rights reserved.
  *
- * Authors: Stig Bakken <ssb@php.net>
- *          Chuck Hagenbuch <chuck@horde.org>
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * o Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * o Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ * o The names of the authors may not be used to endorse or promote
+ *   products derived from this software without specific prior written
+ *   permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * @category  Net
  * @package   Net_Socket
  * @author    Stig Bakken <ssb@php.net>
  * @author    Chuck Hagenbuch <chuck@horde.org>
  * @copyright 1997-2003 The PHP Group
- * @license   http://www.php.net/license/2_02.txt PHP 2.02
+ * @license   http://opensource.org/licenses/bsd-license.php BSD-2-Clause
  * @link      http://pear.php.net/packages/Net_Socket
  */
 
@@ -40,7 +57,7 @@ define('NET_SOCKET_ERROR', 4);
  * @author    Stig Bakken <ssb@php.net>
  * @author    Chuck Hagenbuch <chuck@horde.org>
  * @copyright 1997-2003 The PHP Group
- * @license   http://www.php.net/license/2_02.txt PHP 2.02
+ * @license   http://opensource.org/licenses/bsd-license.php BSD-2-Clause
  * @link      http://pear.php.net/packages/Net_Socket
  */
 class Net_Socket extends PEAR

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "include-path": [
         "./"
     ],
-    "license": "PHP License",
+    "license": "BSD-2-Clause",
     "name": "pear/net_socket",
     "support": {
         "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Net_Socket",

--- a/package.xml
+++ b/package.xml
@@ -34,7 +34,7 @@
   <release>stable</release>
   <api>stable</api>
  </stability>
- <license uri="http://www.php.net/license/2_02.txt">PHP License</license>
+ <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD-2-Clause</license>
  <notes>
 * Set minimum PHP version to 5.4.0
 * Set minimum PEAR version to 1.10.1


### PR DESCRIPTION
Update the license to a BSD-2-Clause. Both authors have agreed to this
license change.

Fixes pear bug 17526: https://pear.php.net/bugs/bug.php?id=17526